### PR TITLE
Add deletion and replacement tests

### DIFF
--- a/source/lib/treedistance.d
+++ b/source/lib/treedistance.d
@@ -69,3 +69,40 @@ unittest
     assert(ted(a, a) == 0);
     assert(ted(a, b) == 1); // one insertion
 }
+
+unittest
+{
+    Node leaf(NodeKind k, string v)
+    {
+        return Node(k, v, []);
+    }
+
+    auto original = Node(NodeKind.Other, "", [
+        leaf(NodeKind.Identifier, "<id>"),
+        leaf(NodeKind.Literal, "<lit>")
+    ]);
+    auto removed = Node(NodeKind.Other, "", [
+        leaf(NodeKind.Identifier, "<id>")
+    ]);
+
+    assert(ted(original, removed) == 1); // one deletion
+}
+
+unittest
+{
+    Node leaf(NodeKind k, string v)
+    {
+        return Node(k, v, []);
+    }
+
+    auto original = Node(NodeKind.Other, "", [
+        leaf(NodeKind.Identifier, "<id>"),
+        leaf(NodeKind.Literal, "<lit>")
+    ]);
+    auto replaced = Node(NodeKind.Other, "", [
+        leaf(NodeKind.Keyword, "for"),
+        leaf(NodeKind.Literal, "<lit>")
+    ]);
+
+    assert(ted(original, replaced) == 1); // one replacement
+}


### PR DESCRIPTION
## Summary
- add more treedistance unittest cases for deleting and replacing children

## Testing
- `dub test --coverage --coverage-ctfe`
- `dub run -- --dir source/lib --exclude-unittests --threshold=0.9 --min-lines=3`


------
https://chatgpt.com/codex/tasks/task_e_686459198968832c867db1ba4c2f9087