### PR TITLE
Routine maintenance

### DIFF
--- a/source/lib/treediff.d
+++ b/source/lib/treediff.d
@@ -810,3 +810,17 @@ int bar(int n){ int i=0; while(i<n){ ++i; } return i; }
     // do-while vs while loops retain partial structural similarity
     assert(isClose(sim, 0.461538, 0.01));
 }
+
+/// Basic tokenization helpers
+unittest
+{
+    // identifiers and literals should be replaced while keywords remain
+    string norm = "foo 42 return";
+    auto tokens = normalizeTokens(norm);
+    assert(tokens == ["<id>", "<lit>", "return"]);
+    assert(normalizedTokenCount(norm) == 3);
+
+    FunctionInfo f;
+    f.normalized = norm;
+    assert(normalizedTokenCount(f) == 3);
+}


### PR DESCRIPTION
## Summary
- extend tests for token normalization

## Testing
- `dub test --coverage --coverage-ctfe`
- `dub run -- --dir source/lib --exclude-unittests --threshold=0.9 --min-lines=3`


------
https://chatgpt.com/codex/tasks/task_e_686845281b20832c897f6325669aaa96