### PR TITLE
Replace token count with node count

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ dub run similarity-d -- [options]
 - `--dir` &lt;path&gt;  Directory to search for `.d` source files (defaults to current directory).
 - `--threshold` &lt;float&gt;  Similarity threshold used to decide matches.
 - `--min-lines` &lt;integer&gt;  Minimum number of lines in a function to be considered.
-- `--min-tokens` &lt;integer&gt;  Minimum number of normalized tokens (default 30).
+- `--min-nodes` &lt;integer&gt;  Minimum number of normalized AST nodes (default 30).
 - `--no-size-penalty`  Disable length penalty when computing similarity.
 - `--print`  Print the snippet of each function when reporting results.
 - `--cross-file`[=true|false]  Allow comparison across different files (default `true`). Use `--cross-file=false` to limit comparisons within each file.
@@ -44,16 +44,16 @@ contains a couple of `.d` files and a short README describing the scenario.
 
 ### `samples/basic`
 
-This directory has two almost identical functions. Lower the token filter to
+This directory has two almost identical functions. Lower the node filter to
 see the match:
 
 ```bash
-$ dub run -- --dir samples/basic --min-tokens=0
+$ dub run -- --dir samples/basic --min-nodes=0
 samples/basic\file_a.d:3-9 <-> samples/basic\file_b.d:3-9 score=1 priority=7
 samples/basic\file_a.d:20-26 <-> samples/basic\file_b.d:20-26 score=1 priority=7
 ```
 
-Running without `--min-tokens=0` prints nothing because the default value of 20
+Running without `--min-nodes=0` prints nothing because the default value of 20
 filters out these tiny functions.
 
 ### `samples/threshold`
@@ -69,7 +69,7 @@ No similar functions found.
 Lowering the threshold reveals a partial match:
 
 ```bash
-$ dub run -- --dir samples/threshold --threshold=0.3 --min-tokens=0 --cross-file=false
+$ dub run -- --dir samples/threshold --threshold=0.3 --min-nodes=0 --cross-file=false
 samples/threshold\a.d:1-7 <-> samples/threshold\a.d:9-17 score=0.346939 priority=3.12245
 ```
 

--- a/source/cli/main.d
+++ b/source/cli/main.d
@@ -25,7 +25,7 @@ void main(string[] args)
 {
     double threshold = 0.85;
     size_t minLines = 5;
-    size_t minTokens = 20;
+    size_t minNodes = 20;
     bool noSizePenalty = false;
     bool printResult = false;
     bool crossFile = true;
@@ -38,7 +38,7 @@ void main(string[] args)
         "print", &printResult,
         "no-size-penalty", &noSizePenalty,
         "cross-file", &crossFile,
-        "min-tokens", &minTokens,
+        "min-nodes", &minNodes,
         "dir", &dir,
         "exclude-unittests", &excludeUnittests
     );
@@ -54,7 +54,7 @@ void main(string[] args)
 
     auto funcs = collectFunctionsInDir(dir, !excludeUnittests);
     bool found = false;
-    collectMatches(funcs, threshold, minLines, minTokens,
+    collectMatches(funcs, threshold, minLines, minNodes,
             noSizePenalty, crossFile, (CrossMatch m)
     {
         found = true;

--- a/source/lib/crossreport.d
+++ b/source/lib/crossreport.d
@@ -3,7 +3,7 @@ module crossreport;
 import std.algorithm : sort, max;
 import std.range : isOutputRange, put;
 import functioncollector : FunctionInfo, collectFunctionsFromSource;
-import treediff : treeSimilarity, normalizedTokenCount;
+import treediff : treeSimilarity, nodeCount;
 
 /**
  * Detailed information about a detected match between two functions.
@@ -42,14 +42,14 @@ struct CrossMatch
 
 /// Generate cross matches from collected functions and output each match via `sink`.
 void collectMatches(Sink)(FunctionInfo[] funcs, double threshold, size_t minLines,
-        size_t minTokens, bool noSizePenalty, bool crossFile, auto ref Sink sink)
+        size_t minNodes, bool noSizePenalty, bool crossFile, auto ref Sink sink)
     if (isOutputRange!(Sink, CrossMatch))
 {
     CrossMatch[] matches;
-    size_t[FunctionInfo] tokenCountCache;
+    size_t[FunctionInfo] nodeCountCache;
     foreach (f; funcs)
     {
-        tokenCountCache[f] = normalizedTokenCount(f);
+        nodeCountCache[f] = nodeCount(f);
     }
 
     foreach (i, f1; funcs)
@@ -57,7 +57,7 @@ void collectMatches(Sink)(FunctionInfo[] funcs, double threshold, size_t minLine
         auto len1 = f1.endLine - f1.startLine + 1;
         if (len1 < minLines)
             continue;
-        if (tokenCountCache[f1] < minTokens)
+        if (nodeCountCache[f1] < minNodes)
         {
             continue;
         }
@@ -67,7 +67,7 @@ void collectMatches(Sink)(FunctionInfo[] funcs, double threshold, size_t minLine
             auto len2 = f2.endLine - f2.startLine + 1;
             if (len2 < minLines)
                 continue;
-            if (tokenCountCache[f2] < minTokens)
+            if (nodeCountCache[f2] < minNodes)
                 continue;
             if (!crossFile && f1.file != f2.file)
                 continue;


### PR DESCRIPTION
## Summary
- drop token-based helpers from `treediff`
- add `nodeCount` helper to compute AST node totals
- update CLI docs to use `--min-nodes`
- remove dead imports and code

## Testing
- `dub test --coverage --coverage-ctfe`
- `dub run -- --dir source/lib --exclude-unittests --threshold=0.9 --min-lines=3`


------
https://chatgpt.com/codex/tasks/task_e_686854cc7e00832c87bfc8921f405934