### PR TITLE
Replace token count with node count

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ dub run similarity-d -- [options]
 - `--dir` &lt;path&gt;  Directory to search for `.d` source files (defaults to current directory).
 - `--threshold` &lt;float&gt;  Similarity threshold used to decide matches.
 - `--min-lines` &lt;integer&gt;  Minimum number of lines in a function to be considered.
-- `--min-tokens` &lt;integer&gt;  Minimum number of normalized tokens (default 30).
+- `--min-tokens` &lt;integer&gt;  Minimum number of normalized AST nodes (default 20).
 - `--no-size-penalty`  Disable length penalty when computing similarity.
 - `--print`  Print the snippet of each function when reporting results.
 - `--cross-file`[=true|false]  Allow comparison across different files (default `true`). Use `--cross-file=false` to limit comparisons within each file.

--- a/source/lib/crossreport.d
+++ b/source/lib/crossreport.d
@@ -3,7 +3,7 @@ module crossreport;
 import std.algorithm : sort, max;
 import std.range : isOutputRange, put;
 import functioncollector : FunctionInfo, collectFunctionsFromSource;
-import treediff : treeSimilarity, normalizedTokenCount;
+import treediff : treeSimilarity, nodeCount;
 
 /**
  * Detailed information about a detected match between two functions.
@@ -46,10 +46,10 @@ void collectMatches(Sink)(FunctionInfo[] funcs, double threshold, size_t minLine
     if (isOutputRange!(Sink, CrossMatch))
 {
     CrossMatch[] matches;
-    size_t[FunctionInfo] tokenCountCache;
+    size_t[FunctionInfo] nodeCountCache;
     foreach (f; funcs)
     {
-        tokenCountCache[f] = normalizedTokenCount(f);
+        nodeCountCache[f] = nodeCount(f);
     }
 
     foreach (i, f1; funcs)
@@ -57,7 +57,7 @@ void collectMatches(Sink)(FunctionInfo[] funcs, double threshold, size_t minLine
         auto len1 = f1.endLine - f1.startLine + 1;
         if (len1 < minLines)
             continue;
-        if (tokenCountCache[f1] < minTokens)
+        if (nodeCountCache[f1] < minTokens)
         {
             continue;
         }
@@ -67,7 +67,7 @@ void collectMatches(Sink)(FunctionInfo[] funcs, double threshold, size_t minLine
             auto len2 = f2.endLine - f2.startLine + 1;
             if (len2 < minLines)
                 continue;
-            if (tokenCountCache[f2] < minTokens)
+            if (nodeCountCache[f2] < minTokens)
                 continue;
             if (!crossFile && f1.file != f2.file)
                 continue;


### PR DESCRIPTION
## Summary
- drop token-based helpers from `treediff`
- add `nodeCount` helper to compute AST node totals
- update CLI docs to use `--min-tokens` name while describing node-based filtering
- remove dead imports and code
- update unit tests for the new helper

## Testing
- `dub test --coverage --coverage-ctfe`
- `dub run -- --dir source/lib --exclude-unittests --threshold=0.9 --min-lines=3`


------
https://chatgpt.com/codex/tasks/task_e_686854cc7e00832c87bfc8921f405934