### PR TITLE
Add documentation for similarity scoring

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,8 @@ The CLI compares all functions it finds in the specified directory and prints an
 Each result lists the two locations and the calculated similarity.
 The TSED algorithm normalizes identifiers and literals before calculating an edit-distance based score.
 
+When computing similarity a length penalty is applied so that short functions do not dominate the results. This behaviour can be disabled with `--no-size-penalty` if you want the raw tree edit distance score.
+
 Example:
 
 ```bash

--- a/source/lib/crossreport.d
+++ b/source/lib/crossreport.d
@@ -40,7 +40,18 @@ struct CrossMatch
     string snippetB;
 }
 
-/// Generate cross matches from collected functions and output each match via `sink`.
+/**
+ * Generate cross matches from the given set of functions.
+ *
+ * Params:
+ *   funcs = Array of functions to compare.
+ *   threshold = Minimum similarity score required to report a match.
+ *   minLines = Skip functions shorter than this many lines.
+ *   minTokens = Skip functions whose normalized AST has fewer tokens.
+ *   noSizePenalty = If true, disable the length penalty applied during similarity calculation.
+ *   crossFile = When false, only compare functions that originate from the same file.
+ *   sink = Output range that receives each `CrossMatch` result.
+ */
 void collectMatches(Sink)(FunctionInfo[] funcs, double threshold, size_t minLines,
         size_t minTokens, bool noSizePenalty, bool crossFile, auto ref Sink sink)
     if (isOutputRange!(Sink, CrossMatch))

--- a/source/lib/treediff.d
+++ b/source/lib/treediff.d
@@ -329,6 +329,9 @@ private Node stmtToNode(Statement s)
     return Node(NodeKind.Other, "stmt", []);
 }
 
+/// Convert a `FunctionInfo` instance into a simplified AST used for similarity
+/// comparisons.  Identifiers and literals are normalized and the resulting tree
+/// is rooted at a single placeholder node.
 public Node normalizedAst(FunctionInfo f)
 {
     Node[] children;
@@ -417,6 +420,10 @@ C foo(){
     assert(contains(ast, "assert"));
 }
 
+/// Compute a similarity score between two functions using tree edit distance.
+/// When `sizePenalty` is enabled the result is scaled by the ratio of the
+/// smaller tree size to the larger one so that very small functions do not
+/// receive disproportionately high scores.
 public double treeSimilarity(FunctionInfo a, FunctionInfo b, bool sizePenalty=true)
 {
     auto ta = normalizedAst(a);


### PR DESCRIPTION
## Summary
- clarify the effect of the size penalty in README
- document AST normalization and tree similarity functions
- expand `collectMatches` documentation to describe parameters

## Testing
- `dub test --coverage --coverage-ctfe`
- `dub run -- --dir source/lib --exclude-unittests --threshold=0.9 --min-lines=3`


------
https://chatgpt.com/codex/tasks/task_e_68685d532680832cbd41a98b0596d580