### PR TITLE
Add CI workflow and badge

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,30 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        dlang: [dmd-latest, ldc-latest]
+    steps:
+      - uses: actions/checkout@v3
+      - name: Setup D compiler
+        uses: dlang-community/setup-dlang@v1
+        with:
+          compiler: ${{ matrix.dlang }}
+      - name: Cache Dub packages
+        uses: actions/cache@v3
+        with:
+          path: ~/.dub/packages
+          key: dub-${{ runner.os }}-${{ matrix.dlang }}-${{ hashFiles('dub.selections.json') }}
+          restore-keys: dub-${{ runner.os }}-${{ matrix.dlang }}-
+      - name: Run tests
+        run: dub test --coverage --coverage-ctfe
+      - name: CLI smoke test
+        run: dub run -- --dir source/lib --exclude-unittests --threshold=0.9 --min-lines=3

--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 # similarity-d
+[![CI](https://github.com/lempiji/similarity-d/actions/workflows/ci.yml/badge.svg)](https://github.com/lempiji/similarity-d/actions/workflows/ci.yml)
 
 similarity-d is a command-line tool written in D for finding similar functions in a project.
 It uses a Tree Edit Distance (TED) algorithm to compare normalized abstract syntax trees.


### PR DESCRIPTION
## Summary
- add GitHub Actions workflow that runs tests and a CLI smoke test on dmd and ldc
- link new workflow status badge in the README

## Testing
- `dub test --coverage --coverage-ctfe`
- `dub run -- --dir source/lib --exclude-unittests --threshold=0.9 --min-lines=3`


------
https://chatgpt.com/codex/tasks/task_e_686861604384832cb1b64401a9a757c2