### PR TITLE
Add CLI output test

### DIFF
--- a/source/cli/main.d
+++ b/source/cli/main.d
@@ -2,23 +2,55 @@ module cli.main;
 
 import std.stdio : writeln;
 import std.getopt : getopt, defaultGetoptPrinter, GetoptResult;
+import std.array : join;
+import std.algorithm.searching : canFind;
 
 version(unittest)
 {
     import functioncollector;
     alias FunctionInfo = functioncollector.FunctionInfo;
     __gshared bool lastIncludeUnittests;
+    __gshared string[] capturedOutput;
+
+    // Replace writeln so output can be inspected by tests
+    void writeln(T...)(T args)
+    {
+        import std.conv : text;
+        capturedOutput ~= text(args);
+    }
+
+    // Provide stub implementations for CLI dependencies
     FunctionInfo[] collectFunctionsInDir(string dir, bool includeUnittests = true)
     {
         lastIncludeUnittests = includeUnittests;
         return [];
     }
+
+    import crossreport : CrossMatch;
+
+    void collectMatches(FunctionInfo[] funcs, double threshold, size_t minLines,
+            size_t minTokens, bool noSizePenalty, bool crossFile,
+            scope void delegate(CrossMatch) sink)
+    {
+        CrossMatch m;
+        m.fileA = "a.d";
+        m.startA = 1;
+        m.endA = 1;
+        m.fileB = "b.d";
+        m.startB = 1;
+        m.endB = 1;
+        m.similarity = 1.0;
+        m.priority = 1.0;
+        m.snippetA = "int foo(){ return 1; }";
+        m.snippetB = "int bar(){ return 1; }";
+        sink(m);
+    }
 }
 else
 {
     import functioncollector : collectFunctionsInDir;
+    import crossreport : collectMatches, CrossMatch;
 }
-import crossreport : collectMatches, CrossMatch;
 import dmd.frontend : initDMD, deinitializeDMD;
 
 void main(string[] args)
@@ -82,4 +114,13 @@ unittest
     assert(lastIncludeUnittests == true);
     main(["app", "--dir", dir, "--exclude-unittests"]);
     assert(lastIncludeUnittests == false);
+}
+
+unittest
+{
+    // verify --print outputs function snippets
+    capturedOutput.length = 0;
+    main(["app", "--print"]);
+    auto joined = capturedOutput.join();
+    assert(joined.canFind("int foo()") || joined.canFind("int bar()"));
 }


### PR DESCRIPTION
## Summary
- stub `writeln` and `collectMatches` under `version(unittest)` to capture CLI output
- add a new unittest verifying `--print` prints stored snippets

## Testing
- `dub test --coverage --coverage-ctfe`
- `dub run -- --dir source/lib --exclude-unittests --threshold=0.9 --min-lines=3`

------
https://chatgpt.com/codex/tasks/task_e_68689bb9c698832cbe5a84593db6d8a6