### PR TITLE
Add explanation comment for funcDecl

### DIFF
--- a/source/lib/functioncollector.d
+++ b/source/lib/functioncollector.d
@@ -27,6 +27,8 @@ public struct FunctionInfo
     string snippet;    /// raw function text
     string normalized; /// normalized body text
 
+    /// Stores the DMD AST node for this function, enabling further analysis
+    /// and tests.
     FuncDeclaration funcDecl;
 }
 


### PR DESCRIPTION
## Summary
- clarify why `funcDecl` is stored in `FunctionInfo`

## Testing
- `dub test --coverage --coverage-ctfe`
- `dub run -- --dir source/lib --exclude-unittests --threshold=0.9 --min-lines=3`


------
https://chatgpt.com/codex/tasks/task_e_68694c42f514832cac0a11be4f792f95