### PR TITLE
Add lastHelpWanted for CLI help tests

### DIFF
--- a/source/cli/main.d
+++ b/source/cli/main.d
@@ -17,6 +17,7 @@ version(unittest)
     __gshared bool lastCrossFile;
     __gshared bool lastNoSizePenalty;
     __gshared bool lastPrintResult;
+    __gshared bool lastHelpWanted;
     FunctionInfo[] collectFunctionsInDir(string dir, bool includeUnittests = true)
     {
         lastIncludeUnittests = includeUnittests;
@@ -60,6 +61,7 @@ void main(string[] args)
         lastCrossFile = crossFile;
         lastNoSizePenalty = noSizePenalty;
         lastPrintResult = printResult;
+        lastHelpWanted = helpInfo.helpWanted;
     }
 
     if (helpInfo.helpWanted)
@@ -96,6 +98,8 @@ void main(string[] args)
 unittest
 {
     auto dir = ".";
+    main(["app", "--help"]);
+    assert(lastHelpWanted == true);
     lastIncludeUnittests = true;
     main(["app", "--dir", dir]);
     assert(lastIncludeUnittests == true);


### PR DESCRIPTION
## Summary
- store help option state in `source/cli/main.d`
- expose helpWanted value for unittests
- verify help command in CLI unittests

## Testing
- `dub test --coverage --coverage-ctfe`
- `dub run -- --dir source/lib --exclude-unittests --threshold=0.9 --min-lines=3`


------
https://chatgpt.com/codex/tasks/task_e_6869f2ddb3a8832c8a65d2f9d9077442