### PR TITLE
Add coverage check script

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,5 +26,7 @@ jobs:
           restore-keys: dub-${{ runner.os }}-${{ matrix.dlang }}-
       - name: Run tests
         run: dub test --coverage --coverage-ctfe
+      - name: Verify coverage
+        run: ./scripts/check-coverage.sh
       - name: CLI smoke test
         run: dub run -- --dir source/lib --exclude-unittests --threshold=0.9 --min-lines=3

--- a/scripts/check-coverage.sh
+++ b/scripts/check-coverage.sh
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+shopt -s nullglob
+files=(source-*.lst)
+if [[ ${#files[@]} -eq 0 ]]; then
+  echo "No coverage files found." >&2
+  exit 1
+fi
+
+declare -i fail=0
+for f in "${files[@]}"; do
+  last_line=$(tail -n 1 "$f" | tr -d '\r')
+  if [[ $last_line =~ ([0-9]+)% ]]; then
+    perc=${BASH_REMATCH[1]}
+    if (( perc < 70 )); then
+      echo "Coverage for $f is below 70%: ${perc}%" >&2
+      fail=1
+    fi
+  else
+    echo "Could not parse coverage percentage from $f" >&2
+    fail=1
+  fi
+done
+
+if (( fail )); then
+  echo "Coverage check failed." >&2
+  exit 1
+fi
+
+echo "All coverage files meet the threshold."


### PR DESCRIPTION
## Summary
- add scripts/check-coverage.sh to fail CI when coverage drops below 70%
- run the coverage script in the CI workflow

## Testing
- `dub test --coverage --coverage-ctfe`
- `./scripts/check-coverage.sh`


------
https://chatgpt.com/codex/tasks/task_e_6869f2ec0774832cb7f66e63f7049b5e