### PR TITLE
Update README with coverage check note

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,6 +104,8 @@ dub test --coverage --coverage-ctfe
 
 After running tests, inspect the `source-*.lst` files and confirm the final two
 lines show coverage of at least 70%.
+You can automate this check by running `scripts/check-coverage.sh` which will
+exit with an error if any coverage file is below the threshold.
 
 To verify the command line interface still works, invoke it with a minimal
 configuration:


### PR DESCRIPTION
## Summary
- document `scripts/check-coverage.sh` in README

## Testing
- `dub test --coverage --coverage-ctfe`
- `dub run -- --dir source/lib --exclude-unittests --threshold=0.9 --min-lines=3`


------
https://chatgpt.com/codex/tasks/task_e_686a217a96b0832cab3e1296ea654b55