### PR TITLE
Fix struct copy for unit test flag guard

### DIFF
--- a/source/lib/functioncollector.d
+++ b/source/lib/functioncollector.d
@@ -39,6 +39,7 @@ public struct FunctionInfo
 /// the instance.
 private struct UnitTestFlagGuard
 {
+    @disable this(this);
     this(bool enabled)
     {
         _prev = global.params.useUnitTests;


### PR DESCRIPTION
## Summary
- avoid accidental copying for `UnitTestFlagGuard`

## Testing
- `dub test --coverage --coverage-ctfe`
- `dub run -- --dir source/lib --exclude-unittests --threshold=0.9 --min-lines=3`


------
https://chatgpt.com/codex/tasks/task_e_686a21707fb0832caf345b1f08caccf1