### PR TITLE
Add ADR 0001 for default nested collection

### DIFF
--- a/docs/design/adr/0001-default-collect-nested.md
+++ b/docs/design/adr/0001-default-collect-nested.md
@@ -1,0 +1,26 @@
+---
+title: Default Collect Nested Functions
+date: 2025-07-06
+status: Accepted
+---
+
+# ADR 0001: Default Collect Nested Functions
+
+Originating Proposal: docs/design/proposals/0001-nested-function-collection.md
+
+## Context
+Proposal 0001 describes adding an `excludeNested` option so users can
+opt out of collecting nested functions. The goal is to make the tool
+more helpful by inspecting all functions that might be duplicated,
+including those declared inside other functions.
+
+## Decision
+Nested functions will be collected by default. The collector and CLI
+expose an `excludeNested` flag to skip nested declarations when the
+user does not need them.
+
+## Consequences
+- Improves similarity detection for projects that rely heavily on
+  nested functions.
+- Slightly increases memory use and processing time for large code
+  bases, which can be mitigated by `--exclude-nested`.

--- a/docs/design/adr/INDEX.md
+++ b/docs/design/adr/INDEX.md
@@ -2,4 +2,4 @@
 
 | Number | Title | Status | Date |
 |--------|-------|--------|------|
-|        |       |        |      |
+| 0001 | Default Collect Nested Functions | Accepted | 2025-07-06 |


### PR DESCRIPTION
## Summary
- document decision to collect nested functions by default
- list ADR 0001 in the index

Originating Proposal: docs/design/proposals/0001-nested-function-collection.md

## Testing
- `dub test --coverage --coverage-ctfe`
- `dub run -- --dir source/lib --exclude-unittests --threshold=0.9 --min-lines=3`


------
https://chatgpt.com/codex/tasks/task_e_686a40a4bc34832cac9fbef061cb2c28