### PR TITLE
Update README with coverage check script instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,10 +103,13 @@ coverage information to be generated and kept above 70% for each module.
 dub test --coverage --coverage-ctfe
 ```
 
-After running tests, inspect the `source-*.lst` files and confirm the final two
-lines show coverage of at least 70%.
-You can automate this check by running `scripts/check-coverage.sh` which will
-exit with an error if any coverage file is below the threshold.
+After running the tests, run the coverage check script to ensure each
+`source-*.lst` file reports at least 70% coverage:
+
+```bash
+./scripts/check-coverage.sh
+```
+The script exits with an error if any coverage file is below the threshold.
 
 To verify the command line interface still works, invoke it with a minimal
 configuration:


### PR DESCRIPTION
## Summary
- clarify the development section in README
- recommend running `./scripts/check-coverage.sh` to verify coverage

## Testing
- `dub test --coverage --coverage-ctfe`
- `./scripts/check-coverage.sh`


------
https://chatgpt.com/codex/tasks/task_e_686a40a5b2ac832ca5cbc867fca36726