### PR TITLE
Add scripting guidelines for scripts directory

### DIFF
--- a/scripts/AGENTS.md
+++ b/scripts/AGENTS.md
@@ -3,7 +3,7 @@
 Scripts in this directory must be cross‑platform and written in the D programming language. Use `rdmd` to run them so they work on both Windows and Linux.
 
 ```
-#!/usr/bin/env -S rdmd
+#!/usr/bin/env rdmd
 ```
 
 Typical invocation:

--- a/scripts/AGENTS.md
+++ b/scripts/AGENTS.md
@@ -1,0 +1,15 @@
+# Scripting Guidelines
+
+Scripts in this directory must be cross‑platform and written in the D programming language. Use `rdmd` to run them so they work on both Windows and Linux.
+
+```
+#!/usr/bin/env -S rdmd
+```
+
+Typical invocation:
+
+```
+rdmd path/to/script.d
+```
+
+Avoid platform‑specific shell commands inside the scripts.


### PR DESCRIPTION
## Summary
- document D-based scripting practices under `scripts/`

## Testing
- `dub test --coverage --coverage-ctfe`
- `dub run -- --dir source/lib --exclude-unittests --threshold=0.9 --min-lines=3`


------
https://chatgpt.com/codex/tasks/task_e_686a5456c328832cba4943b42363d575