### PR TITLE
Fix shebang for rdmd script per guidelines

### DIFF
--- a/scripts/check_coverage.d
+++ b/scripts/check_coverage.d
@@ -1,4 +1,4 @@
-#!/usr/bin/env -S rdmd
+#!/usr/bin/env rdmd
 import std.stdio;
 import std.file : dirEntries, SpanMode, readText;
 import std.array : array;


### PR DESCRIPTION
## Summary
- adjust scripts/check_coverage.d shebang to use `#!/usr/bin/env rdmd`

## Testing
- `dub test --coverage --coverage-ctfe`
- `dub run -- --dir source/lib --exclude-unittests --threshold=0.9 --min-lines=3`


------
https://chatgpt.com/codex/tasks/task_e_686a5ecda1cc832c8b82516f73716f27