### PR TITLE
Add design docs overview

### DIFF
--- a/docs/design/README.md
+++ b/docs/design/README.md
@@ -1,0 +1,13 @@
+This directory stores design documentation for *similarity-d*.
+
+Design documents come in two forms:
+
+- **Proposals** – feature ideas or enhancements.
+- **ADRs** – Architecture Decision Records for system-wide choices.
+
+See [AGENTS.md](AGENTS.md) for templates and workflow details.
+Existing documents are indexed in [proposals/INDEX.md](proposals/INDEX.md)
+and [adr/INDEX.md](adr/INDEX.md).
+
+Before implementing a new feature, ensure the corresponding Proposal is
+**Approved** and any ADRs are **Accepted**.


### PR DESCRIPTION
## Summary
- document the purpose of design docs
- link to `AGENTS.md` and document indexes
- remind contributors to get proposals/ADRs approved first

## Testing
- `dub test --coverage --coverage-ctfe`
- `dub run -- --dir source/lib --exclude-unittests --threshold=0.9 --min-lines=3`


------
https://chatgpt.com/codex/tasks/task_e_686a7f01a5cc832ca3ef1acf1656beda