### PR TITLE
Add version flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ dub run similarity-d -- [options]
 - `--cross-file`[=true|false]  Allow comparison across different files (default `true`). Use `--cross-file=false` to limit comparisons within each file.
 - `--exclude-unittests`  Skip `unittest` blocks when collecting functions.
 - `--exclude-nested`  Ignore nested functions and only collect top-level declarations.
+- `--version`  Print the package version and exit.
 
 The CLI compares all functions it finds in the specified directory and prints any matches whose similarity score exceeds the threshold.
 Each result lists the two locations and the calculated similarity.
@@ -41,6 +42,8 @@ Example:
 $ similarity-d --threshold=0.8 --min-lines=3 --dir=source --exclude-nested
 # disable cross-file comparisons
 $ similarity-d --threshold=0.8 --cross-file=false
+$ similarity-d --version
+0.1.0
 ```
 
 ## Remarks

--- a/dub.json
+++ b/dub.json
@@ -1,6 +1,7 @@
 {
     "name": "similarity-d",
     "description": "Command line utilities for text similarity experiments.",
+    "version": "0.1.0",
     "authors": ["lempiji"],
     "license": "MIT",
     "dependencies": {
@@ -11,5 +12,6 @@
     "targetPath": "bin",
     "mainSourceFile": "source/cli/main.d",
     "lflags-linux": ["--allow-multiple-definition"],
-    "lflags-windows": ["/FORCE:MULTIPLE"]
+    "lflags-windows": ["/FORCE:MULTIPLE"],
+    "stringImportPaths": ["."]
 }


### PR DESCRIPTION
## Summary
- add version data to dub.json and allow importing it
- document and demonstrate new `--version` flag
- implement version flag in `main.d`
- test version flag behavior

## Testing
- `dub test --coverage --coverage-ctfe`
- `dub run -- --dir source/lib --exclude-unittests --threshold=0.9 --min-lines=3`

------
https://chatgpt.com/codex/tasks/task_e_686a7f074d68832c8929f430c5924069