### PR TITLE
Add Japanese translation for design README

### DIFF
--- a/docs/design/README.ja.md
+++ b/docs/design/README.ja.md
@@ -1,0 +1,11 @@
+このディレクトリには *similarity-d* の設計ドキュメントが保存されています。
+
+設計ドキュメントには以下の2種類があります。
+
+- **Proposals** – 機能追加や改善案
+- **ADRs** – システム全体に関わる選択を記録する Architecture Decision Record
+
+テンプレートとワークフローの詳細は [AGENTS.md](AGENTS.md) を参照してください。
+既存のドキュメントは [proposals/INDEX.md](proposals/INDEX.md) と [adr/INDEX.md](adr/INDEX.md) に一覧化されています。
+
+新しい機能を実装する前に、対応する Proposal が **Approved** であり、必要な ADR が **Accepted** となっていることを確認してください。

--- a/docs/design/README.md
+++ b/docs/design/README.md
@@ -1,5 +1,7 @@
 This directory stores design documentation for *similarity-d*.
 
+Japanese readers can find a translated version in [README.ja.md](README.ja.md).
+
 Design documents come in two forms:
 
 - **Proposals** – feature ideas or enhancements.


### PR DESCRIPTION
## Summary
- translate `docs/design/README.md` into Japanese
- cross-link English README to the new Japanese version

## Testing
- `dub test --coverage --coverage-ctfe`
- `dub run -- --dir source/lib --exclude-unittests --threshold=0.9 --min-lines=3`


------
https://chatgpt.com/codex/tasks/task_e_686b05c2244c832c8be34eadbf685002