### PR TITLE
Add Japanese translation of design README

### DIFF
--- a/docs/design/README.ja.md
+++ b/docs/design/README.ja.md
@@ -1,0 +1,13 @@
+このディレクトリには *similarity-d* の設計ドキュメントが保存されています。
+
+設計ドキュメントは次の2種類です。
+
+- **Proposals** – 機能提案や改善案
+- **ADRs** – システム全体の選択を記録するアーキテクチャ決定記録
+
+テンプレートやワークフローの詳細は [AGENTS.md](AGENTS.md) を参照してください。
+既存のドキュメントは [proposals/INDEX.md](proposals/INDEX.md) と
+[adr/INDEX.md](adr/INDEX.md) に一覧があります。
+
+新しい機能を実装する前に、対応する Proposal が **Approved** であり
+関連する ADR が **Accepted** になっていることを確認してください。

--- a/docs/design/README.md
+++ b/docs/design/README.md
@@ -1,3 +1,5 @@
+See [README.ja.md](README.ja.md) for the Japanese version.
+
 This directory stores design documentation for *similarity-d*.
 
 Design documents come in two forms:


### PR DESCRIPTION
## Summary
- translate docs/design/README.md into Japanese
- cross-link docs/design/README.md and README.ja.md

## Testing
- `dub test --coverage --coverage-ctfe`
- `dub run -- --dir source/lib --exclude-unittests --threshold=0.9 --min-lines=3`


------
https://chatgpt.com/codex/tasks/task_e_686b05d98668832c93d8b41d2ba60ad2