### PR TITLE
Add license section to READMEs

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -129,3 +129,8 @@ dub run -- --dir source/lib --exclude-unittests --threshold=0.9 --min-lines=3
 ## コントリビュート
 
 ワークフローやガイドラインは [CONTRIBUTING.md](CONTRIBUTING.md) を参照してください。
+
+## ライセンス
+
+本プロジェクトは [MIT License](LICENSE) のもとで公開されています。
+

--- a/README.md
+++ b/README.md
@@ -144,5 +144,9 @@ dub run -- --dir source/lib --exclude-unittests --threshold=0.9 --min-lines=3
 Refresh dependencies with `dub upgrade` and then run the full test suite with coverage. If the tests pass, verify the CLI works as shown above and commit the updated manifest files. See [AGENTS.md](AGENTS.md#dependency-maintenance-dub) for the detailed procedure.
 
 ## Contributing
-
 See [CONTRIBUTING.md](CONTRIBUTING.md) for workflow and guidelines.
+
+## License
+
+Licensed under the [MIT License](LICENSE).
+


### PR DESCRIPTION
## Summary
- add brief License section with MIT link

## Testing
- `dub test --coverage --coverage-ctfe`
- `dub run -- --dir source/lib --exclude-unittests --threshold=0.9 --min-lines=3`


------
https://chatgpt.com/codex/tasks/task_e_686d18a1ba40832cb5e1ae576205d380