### PR TITLE
Add stdout capture to invalid dir test

### DIFF
--- a/source/cli/main.d
+++ b/source/cli/main.d
@@ -170,7 +170,26 @@ unittest
 
 unittest
 {
+    import std.file : deleteme, remove, readText;
+    import std.algorithm.searching : canFind;
+    import std.stdio : File, stdout;
+
     auto bogus = "./does-not-exist";
+    auto capturePath = deleteme ~ "-cli-main";
+    auto captureFile = File(capturePath, "w+");
+    auto oldStdout = stdout;
+    stdout = captureFile;
+    scope(exit)
+    {
+        stdout.flush();
+        stdout = oldStdout;
+        captureFile.close();
+        remove(capturePath);
+    }
+
     assert(main(["app", "--dir", bogus]) == 1);
+    captureFile.rewind();
+    auto output = readText(capturePath);
+    assert(output.canFind("Invalid directory: " ~ bogus));
     assert(lastShowVersion == false);
 }


### PR DESCRIPTION
## Summary
- test main with a nonexistent directory
- assert that the output reports `Invalid directory:`

## Testing
- `dub test --coverage --coverage-ctfe`
- `dub run -- --dir source/lib --exclude-unittests --threshold=0.9 --min-lines=3`

------
https://chatgpt.com/codex/tasks/task_e_686d18a60250832c9fa00d22b75f9fd0