### PR TITLE
docs: add rdmd usage notes for scripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,7 +126,9 @@ dub test --coverage --coverage-ctfe
 ```
 
 After running the tests, run the coverage check script to ensure each
-`source-*.lst` file reports at least 70% coverage:
+`source-*.lst` file reports at least 70% coverage. Development scripts live in
+the `scripts/` directory, are written in D, and should be executed with
+`rdmd` as described in [scripts/AGENTS.md](scripts/AGENTS.md):
 
 ```bash
 rdmd ./scripts/check_coverage.d


### PR DESCRIPTION
## Summary
- mention that scripts are D programs run via `rdmd`
- reference `scripts/AGENTS.md`

## Testing
- `dub test --coverage --coverage-ctfe`
- `rdmd ./scripts/check_coverage.d`
- `dub run -- --dir source/lib --exclude-unittests --threshold=0.9 --min-lines=3`


------
https://chatgpt.com/codex/tasks/task_e_686d18784f5c832c959d3dc13722f42a