### PR TITLE
Update coverage script docs

### DIFF
--- a/scripts/check_coverage.d
+++ b/scripts/check_coverage.d
@@ -1,4 +1,6 @@
 #!/usr/bin/env rdmd
+// Verify that each generated `source-*.lst` coverage file reports at least
+// a 70% pass rate. Typically run with `rdmd scripts/check_coverage.d`.
 import std.stdio;
 import std.file : dirEntries, SpanMode, readText;
 import std.array : array;


### PR DESCRIPTION
## Summary
- document purpose and usage of `scripts/check_coverage.d`

## Testing
- `dub test --coverage --coverage-ctfe`

------
https://chatgpt.com/codex/tasks/task_e_686d2a5f6a24832cb434320c6230681d