### PR TITLE
Add unit tests for empty trees

### DIFF
--- a/source/lib/treedistance.d
+++ b/source/lib/treedistance.d
@@ -141,3 +141,23 @@ unittest
 
     assert(ted(original, replaced) == 1); // one replacement
 }
+
+
+unittest
+{
+    auto single = leaf(NodeKind.Identifier, "solo");
+    assert(treeSize(single) == 1);
+}
+
+unittest
+{
+    auto empty = Node.init;
+    auto tree = Node(NodeKind.Other, "", [
+        leaf(NodeKind.Identifier, "x"),
+        leaf(NodeKind.Literal, "1")
+    ]);
+
+    assert(ted(empty, tree) == treeSize(tree));
+    assert(ted(tree, empty) == treeSize(tree));
+    assert(ted(empty, empty) == 0);
+}


### PR DESCRIPTION
## Summary
- add coverage for `treeSize` of a leaf
- ensure `ted` handles empty trees properly

## Testing
- `dub test --coverage --coverage-ctfe`
- `dub run -- --dir source/lib --exclude-unittests --threshold=0.9 --min-lines=3`


------
https://chatgpt.com/codex/tasks/task_e_686d2a508aac832c98f4b885de062752