### PR TITLE
Add test for treeSimilarity with empty functions

### DIFF
--- a/source/lib/treediff.d
+++ b/source/lib/treediff.d
@@ -758,3 +758,19 @@ int b(){ return 1; }
     auto sim = treeSimilarity(funcs[0], funcs[1], false);
     assert(sim >= 0 && sim <= 1);
 }
+
+unittest
+{
+    import std.math : isClose;
+
+    scope DmdInitGuard guard = DmdInitGuard.make();
+
+    string code = q{
+void foo(){}
+void bar(){}
+};
+    auto funcs = collectFunctionsFromSource("empty.d", code);
+    assert(funcs.length == 2);
+    auto sim = treeSimilarity(funcs[0], funcs[1]);
+    assert(isClose(sim, 1.0));
+}


### PR DESCRIPTION
## Summary
- add regression test for treeSimilarity on empty functions

## Testing
- `dub test --coverage --coverage-ctfe`
- `./scripts/check_coverage.d`
- `dub run -- --dir source/lib --exclude-unittests --threshold=0.9 --min-lines=3`


------
https://chatgpt.com/codex/tasks/task_e_686d33bc6dd8832c926872bbacf1d7f5