### PR TITLE
Remove trailing whitespace

### DIFF
--- a/docs/design/adr/0001-default-collect-nested.ja.md
+++ b/docs/design/adr/0001-default-collect-nested.ja.md
@@ -4,7 +4,7 @@ date: 2025-07-06
 status: Accepted
 ---
 
-*English version is available [here](0001-default-collect-nested.md).* 
+*English version is available [here](0001-default-collect-nested.md).*
 
 # ADR 0001: デフォルトで入れ子関数を収集する
 

--- a/docs/design/adr/0001-default-collect-nested.md
+++ b/docs/design/adr/0001-default-collect-nested.md
@@ -4,7 +4,7 @@ date: 2025-07-06
 status: Accepted
 ---
 
-*A Japanese translation is available [here](0001-default-collect-nested.ja.md).* 
+*A Japanese translation is available [here](0001-default-collect-nested.ja.md).*
 
 # ADR 0001: Default Collect Nested Functions
 

--- a/docs/design/proposals/0001-nested-function-collection.ja.md
+++ b/docs/design/proposals/0001-nested-function-collection.ja.md
@@ -4,7 +4,7 @@ date: 2025-07-06
 status: Approved
 ---
 
-*English version is available [here](0001-nested-function-collection.md).* 
+*English version is available [here](0001-nested-function-collection.md).*
 
 # 提案: 入れ子関数の収集
 
@@ -27,7 +27,7 @@ status: Approved
 入れ子関数はデフォルトで収集され、このフラグが設定されている場合は無視されます。
 
 ## 代替案
-- 既存の AST ヘルパーではなくカスタムビジターでソースを解析する  
+- 既存の AST ヘルパーではなくカスタムビジターでソースを解析する
   → 単純さのため却下
 
 ## 影響とリスク

--- a/docs/design/proposals/0001-nested-function-collection.md
+++ b/docs/design/proposals/0001-nested-function-collection.md
@@ -4,7 +4,7 @@ date: 2025-07-06
 status: Approved
 ---
 
-*A Japanese translation is available [here](0001-nested-function-collection.ja.md).* 
+*A Japanese translation is available [here](0001-nested-function-collection.ja.md).*
 
 # Proposal: Nested Function Collection
 


### PR DESCRIPTION
## Summary
- clean up trailing whitespace in design docs

## Testing
- `dub test --coverage --coverage-ctfe`
- `dub run -- --dir source/lib --exclude-unittests --threshold=0.9 --min-lines=3`


------
https://chatgpt.com/codex/tasks/task_e_686d33e7db88832c9ca6c688f0b57126