### PR TITLE
Add doc comment and lint step

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,6 +26,8 @@ jobs:
           restore-keys: dub-${{ runner.os }}-${{ matrix.dlang }}-
       - name: Run tests
         run: dub test --coverage --coverage-ctfe
+      - name: Lint sources
+        run: dub lint
       - name: Verify coverage
         run: ./scripts/check_coverage.d
       - name: CLI smoke test

--- a/source/cli/main.d
+++ b/source/cli/main.d
@@ -37,6 +37,7 @@ version(unittest)
 else
 {
     import functioncollector : collectFunctionsInDir;
+    /// Write the supplied version string to standard output.
     void printVersion(string s) { writeln(s); }
 }
 import crossreport : collectMatches, CrossMatch;
@@ -198,7 +199,7 @@ unittest
 
     auto capturePath = deleteme ~ "-cli-print";
     auto captureFile = File(capturePath, "w+");
-    auto oldStdout = stdout;
+    const oldStdout = stdout;
     stdout = captureFile;
     scope(exit)
     {
@@ -233,7 +234,7 @@ unittest
     auto bogus = "./does-not-exist";
     auto capturePath = deleteme ~ "-cli-main";
     auto captureFile = File(capturePath, "w+");
-    auto oldStdout = stdout;
+    const oldStdout = stdout;
     stdout = captureFile;
     scope(exit)
     {
@@ -258,7 +259,7 @@ unittest
 
     auto capturePath = deleteme ~ "-cli-main";
     auto captureFile = File(capturePath, "w+");
-    auto oldStdout = stdout;
+    const oldStdout = stdout;
     stdout = captureFile;
     scope(exit)
     {
@@ -282,7 +283,7 @@ unittest
 
     auto capturePath = deleteme ~ "-cli-main";
     auto captureFile = File(capturePath, "w+");
-    auto oldStdout = stdout;
+    const oldStdout = stdout;
     stdout = captureFile;
     scope(exit)
     {
@@ -306,7 +307,7 @@ unittest
 
     auto capturePath = deleteme ~ "-cli-main";
     auto captureFile = File(capturePath, "w+");
-    auto oldStdout = stdout;
+    const oldStdout = stdout;
     stdout = captureFile;
     scope(exit)
     {


### PR DESCRIPTION
## Summary
- document `printVersion` helper in the CLI
- preserve stdout in tests with `const` binding
- run `dub lint` in CI

## Testing
- `dub test --coverage --coverage-ctfe`
- `dub run -- --dir source/lib --exclude-unittests --threshold=0.9 --min-lines=3`
- `dub lint`

------
https://chatgpt.com/codex/tasks/task_e_686da5230bf4832cb21d86b1dd75226c