### PR TITLE
Resolve lint issues and update docs

### DIFF
--- a/samples/basic/file_a.d
+++ b/samples/basic/file_a.d
@@ -1,5 +1,6 @@
 module file_a;
 
+/// Returns the sum of all elements in `arr`.
 int accumulate(int[] arr)
 {
     int sum = 0;
@@ -8,20 +9,23 @@ int accumulate(int[] arr)
     return sum;
 }
 
+/// Simple animal type used by the examples.
 class Animal
 {
+    /// Name of the animal.
     string name;
 
+    /// Create an `Animal` with the given name.
     this(string name)
     {
         this.name = name;
     }
 
+    /// Print a friendly greeting.
     void speak()
     {
         import std.stdio : writeln;
 
         writeln(name, " says hello!");
         writeln("Wow, ", name, " is happy to see you.");
-    }
-}
+    }}

--- a/samples/basic/file_b.d
+++ b/samples/basic/file_b.d
@@ -1,5 +1,6 @@
 module file_b;
 
+/// Returns the sum of all elements in `arr`.
 long total(long[] arr)
 {
     long sum = 0;
@@ -8,20 +9,23 @@ long total(long[] arr)
     return sum;
 }
 
+/// Simple creature used by the examples.
 class Creature
 {
+    /// Name of the creature.
     string name;
 
+    /// Create a `Creature` with the given name.
     this(string name)
     {
         this.name = name;
     }
 
+    /// Emit an excited scream.
     void scream()
     {
         import std.stdio : writeln;
 
         writeln(name, " screams!");
         writeln("The sound echoes through the forest.");
-    }
-}
+    }}

--- a/samples/nested/file_a.d
+++ b/samples/nested/file_a.d
@@ -1,5 +1,6 @@
 module file_a;
 
+/// Outer function used in nested samples.
 void outerA()
 {
     int addOne(int x)
@@ -11,3 +12,4 @@ void outerA()
     import std.stdio : writeln;
     writeln(y);
 }
+

--- a/samples/nested/file_b.d
+++ b/samples/nested/file_b.d
@@ -1,5 +1,6 @@
 module file_b;
 
+/// Another outer function for nested sample.
 void outerB()
 {
     int addOne(int x)
@@ -11,3 +12,4 @@ void outerB()
     foreach(i; 0 .. 2)
         writeln(addOne(i));
 }
+

--- a/samples/threshold/a.d
+++ b/samples/threshold/a.d
@@ -1,3 +1,4 @@
+/// Short function used by unit tests.
 int shortFunc()
 {
     int x = 0;
@@ -5,6 +6,7 @@ int shortFunc()
         x += i;
     return x;
 }
+/// Slightly longer function used by unit tests.
 
 int biggerFunc()
 {
@@ -15,3 +17,4 @@ int biggerFunc()
         y += 3;
     return y;
 }
+

--- a/source/cli/main.d
+++ b/source/cli/main.d
@@ -8,6 +8,7 @@ import std.getopt : getopt, defaultGetoptPrinter, GetoptResult;
 import std.file : exists, isDir;
 import std.json : parseJSON;
 
+/// Version string extracted from `dub.json`.
 enum packageVersion = parseJSON(import("dub.json"))["version"].str;
 
 version(unittest)
@@ -27,7 +28,7 @@ version(unittest)
     __gshared string lastVersionPrinted;
     __gshared FunctionInfo[] stubFunctions;
     void printVersion(string s) { lastVersionPrinted = s; }
-    FunctionInfo[] collectFunctionsInDir(string dir, bool includeUnittests = true, bool excludeNested = false)
+    FunctionInfo[] collectFunctionsInDir(string _, bool includeUnittests = true, bool excludeNested = false)
     {
         lastIncludeUnittests = includeUnittests;
         lastExcludeNested = excludeNested;

--- a/source/lib/crossreport.d
+++ b/source/lib/crossreport.d
@@ -87,7 +87,7 @@ void collectMatches(Sink)(FunctionInfo[] funcs, double threshold, size_t minLine
             if (!crossFile && f1.file != f2.file)
                 continue;
 
-            auto sim = treeSimilarity(f1, f2, !noSizePenalty);
+            const sim = treeSimilarity(f1, f2, !noSizePenalty);
             if (sim >= threshold)
             {
                 CrossMatch m;
@@ -115,7 +115,7 @@ void collectMatches(Sink)(FunctionInfo[] funcs, double threshold, size_t minLine
 
 unittest
 {
-    scope DmdInitGuard guard = DmdInitGuard.make();
+    scope const(DmdInitGuard) _ = DmdInitGuard.make();
 
     string codeA = q{
 int foo(){ return 1; }
@@ -142,7 +142,7 @@ int bar(){ return 1; }
 
 unittest
 {
-    scope DmdInitGuard guard = DmdInitGuard.make();
+    scope const(DmdInitGuard) _ = DmdInitGuard.make();
 
     string code = q{
 int a(){ return 0; }
@@ -153,14 +153,15 @@ int c(){ return 0; }
     CrossMatch[] matches;
     collectMatches(funcs, 0.0, 1, 1, false, true, (CrossMatch m){ matches ~= m; });
     assert(matches.length == 3); // three pairs
-    foreach(i; 0 .. matches.length - 1)
+    const len = matches.length;
+    foreach(i; 0 .. len - 1)
         assert(matches[i].priority >= matches[i + 1].priority);
 }
 
 unittest
 {
     import std.conv : to;
-    scope DmdInitGuard guard = DmdInitGuard.make();
+    scope const(DmdInitGuard) _ = DmdInitGuard.make();
 
     enum count = 150;
     string code;
@@ -168,14 +169,15 @@ unittest
         code ~= "int fn" ~ i.to!string() ~ "(){ return " ~ i.to!string() ~ "; }\n";
     auto funcs = collectFunctionsFromSource("big.d", code);
     size_t pairs;
-    collectMatches(funcs, 0.0, 1, 1, false, true, (CrossMatch m){ ++pairs; });
-    auto expected = funcs.length * (funcs.length - 1) / 2;
+    const len = funcs.length;
+    collectMatches(funcs, 0.0, 1, 1, false, true, (CrossMatch _){ ++pairs; });
+    const expected = len * (len - 1) / 2;
     assert(pairs == expected);
 }
 
 unittest
 {
-    scope DmdInitGuard guard = DmdInitGuard.make();
+    scope const(DmdInitGuard) _ = DmdInitGuard.make();
 
     string code = q{
 int foo(){
@@ -203,7 +205,7 @@ int bar(){
 
 unittest
 {
-    scope DmdInitGuard guard = DmdInitGuard.make();
+    scope const(DmdInitGuard) _ = DmdInitGuard.make();
 
     string code = q{
 int foo(){
@@ -237,7 +239,7 @@ int bar(){
 unittest
 {
 
-    scope DmdInitGuard guard = DmdInitGuard.make();
+    scope const(DmdInitGuard) _ = DmdInitGuard.make();
 
     string code = q{
 int foo(){ return 1; }
@@ -267,7 +269,7 @@ int bar(){ return 2; }
 unittest
 {
 
-    scope DmdInitGuard guard = DmdInitGuard.make();
+    scope const(DmdInitGuard) _ = DmdInitGuard.make();
 
     string foo = "int foo(){ return 1; }";
     string bar = "int bar(){ return 1; }";

--- a/source/lib/crossreport.d
+++ b/source/lib/crossreport.d
@@ -123,9 +123,8 @@ int foo(){ return 1; }
     string codeB = q{
 int bar(){ return 1; }
 };
-    auto fA = collectFunctionsFromSource("a.d", codeA);
-    auto fB = collectFunctionsFromSource("b.d", codeB);
-    auto all = fA ~ fB;
+    auto all = collectFunctionsFromSource("a.d", codeA) ~
+               collectFunctionsFromSource("b.d", codeB);
 
     CrossMatch[] matches;
     // cross-file disabled should yield no matches

--- a/source/lib/treediff.d
+++ b/source/lib/treediff.d
@@ -370,7 +370,7 @@ unittest
 {
     import std.math : isClose;
 
-    scope DmdInitGuard guard = DmdInitGuard.make();
+    scope const(DmdInitGuard) _ = DmdInitGuard.make();
 
     string code = q{
 int foo(){ return 1; }
@@ -390,7 +390,7 @@ int foo(){ return 1; }
 unittest
 {
 
-    scope DmdInitGuard guard = DmdInitGuard.make();
+    scope const(DmdInitGuard) _ = DmdInitGuard.make();
 
     string code = q{
 int foo(){ return 1; }
@@ -405,7 +405,7 @@ int foo(){ return 1; }
 unittest
 {
 
-    scope DmdInitGuard guard = DmdInitGuard.make();
+    scope const(DmdInitGuard) _ = DmdInitGuard.make();
 
     string code = q{
 class C{ int x; this(int n){ this.x = n; } }
@@ -435,8 +435,8 @@ public double treeSimilarity(FunctionInfo a, FunctionInfo b, bool sizePenalty=tr
     auto sizeB = treeSize(tb) - 1;
     if (sizeA == 0 && sizeB == 0)
         return 1.0;
-    auto dist = ted(ta, tb);
-    auto maxlen = max(sizeA, sizeB);
+    const dist = ted(ta, tb);
+    const maxlen = max(sizeA, sizeB);
     double score = 1.0 - cast(double)dist / maxlen;
     // clamp to [0,1] in case dist > maxlen or negative rounding issues
     if (score < 0) score = 0;
@@ -454,7 +454,7 @@ unittest
 {
     import std.math : isClose;
 
-    scope DmdInitGuard guard = DmdInitGuard.make();
+    scope const(DmdInitGuard) _ = DmdInitGuard.make();
 
     string code = q{
 int foo(int x){ return x + 1; }
@@ -480,7 +480,7 @@ unittest
 {
     import std.math : isClose;
 
-    scope DmdInitGuard guard = DmdInitGuard.make();
+    scope const(DmdInitGuard) _ = DmdInitGuard.make();
 
     string code = q{
 int foo(){ int a = 1; return a; }
@@ -488,7 +488,7 @@ int bar(){ int b = 1; return b; }
 };
     auto funcs = collectFunctionsFromSource("rename.d", code);
     assert(funcs.length == 2);
-    auto sim = treeSimilarity(funcs[0], funcs[1]);
+    const sim = treeSimilarity(funcs[0], funcs[1]);
     // Renaming variables should yield identical trees
     import std.math : isClose;
     assert(isClose(sim, 1.0));
@@ -499,7 +499,7 @@ unittest
 {
     import std.math : isClose;
 
-    scope DmdInitGuard guard = DmdInitGuard.make();
+    scope const(DmdInitGuard) _ = DmdInitGuard.make();
 
     string code = q{
 int foo(int x){ return x + 1; }
@@ -507,7 +507,7 @@ int bar(int x){ return x - 1; }
 };
     auto funcs = collectFunctionsFromSource("op.d", code);
     assert(funcs.length == 2);
-    auto sim = treeSimilarity(funcs[0], funcs[1]);
+    const sim = treeSimilarity(funcs[0], funcs[1]);
     // Only the operator differs -> expect high similarity (~0.8)
     assert(isClose(sim, 0.8, 0.01));
 }
@@ -517,7 +517,7 @@ unittest
 {
     import std.math : isClose;
 
-    scope DmdInitGuard guard = DmdInitGuard.make();
+    scope const(DmdInitGuard) _ = DmdInitGuard.make();
 
     string code = q{
 int foo(){ return 1; }
@@ -525,7 +525,7 @@ int bar(){ return 2; }
 };
     auto funcs = collectFunctionsFromSource("lit.d", code);
     assert(funcs.length == 2);
-    auto sim = treeSimilarity(funcs[0], funcs[1]);
+    const sim = treeSimilarity(funcs[0], funcs[1]);
     // Literal changes shouldn't affect similarity
     import std.math : isClose;
     assert(isClose(sim, 1.0));
@@ -535,7 +535,7 @@ int bar(){ return 2; }
 unittest
 {
 
-    scope DmdInitGuard guard = DmdInitGuard.make();
+    scope const(DmdInitGuard) _ = DmdInitGuard.make();
 
     string code = q{
 int foo(int x){
@@ -548,7 +548,7 @@ int bar(int x){
 };
     auto funcs = collectFunctionsFromSource("if.d", code);
     assert(funcs.length == 2);
-    auto sim = treeSimilarity(funcs[0], funcs[1]);
+    const sim = treeSimilarity(funcs[0], funcs[1]);
     // Extra branch lowers similarity to about 0.05
     assert(sim > 0 && sim < 0.1);
 }
@@ -557,7 +557,7 @@ int bar(int x){
 unittest
 {
 
-    scope DmdInitGuard guard = DmdInitGuard.make();
+    scope const(DmdInitGuard) _ = DmdInitGuard.make();
 
     string code = q{
 int foo(){ return 1; }
@@ -565,7 +565,7 @@ int bar(){ try{ return 1; }catch(Exception e){ return 0; } }
 };
     auto funcs = collectFunctionsFromSource("try.d", code);
     assert(funcs.length == 2);
-    auto sim = treeSimilarity(funcs[0], funcs[1]);
+    const sim = treeSimilarity(funcs[0], funcs[1]);
     // Try/catch wrapper produces similarity around 0.12
     assert(sim > 0.1 && sim < 0.2);
 }
@@ -575,7 +575,7 @@ unittest
 {
     import std.math : isClose;
 
-    scope DmdInitGuard guard = DmdInitGuard.make();
+    scope const(DmdInitGuard) _ = DmdInitGuard.make();
 
     string code = q{
 int foo(int x){ return x + 1; }
@@ -583,7 +583,7 @@ int bar(int x){ return x + 2; }
 };
     auto funcs = collectFunctionsFromSource("leaf.d", code);
     assert(funcs.length == 2);
-    auto sim = treeSimilarity(funcs[0], funcs[1]);
+    const sim = treeSimilarity(funcs[0], funcs[1]);
     // Expression tweak keeps similarity almost perfect
     import std.math : isClose;
     assert(isClose(sim, 1.0));
@@ -593,7 +593,7 @@ int bar(int x){ return x + 2; }
 unittest
 {
 
-    scope DmdInitGuard guard = DmdInitGuard.make();
+    scope const(DmdInitGuard) _ = DmdInitGuard.make();
 
     string code = q{
 int foo(int[] a){ int s=0; for(int i=0;i<a.length;i++) s+=a[i]; return s; }
@@ -601,7 +601,7 @@ int bar(int[] a){ int s=0; foreach(i; a) s+=i; return s; }
 };
     auto funcs = collectFunctionsFromSource("loop.d", code);
     assert(funcs.length == 2);
-    auto sim = treeSimilarity(funcs[0], funcs[1]);
+    const sim = treeSimilarity(funcs[0], funcs[1]);
     // for vs foreach yields around 0.2 similarity
     assert(sim > 0.15 && sim < 0.25);
 }
@@ -610,7 +610,7 @@ int bar(int[] a){ int s=0; foreach(i; a) s+=i; return s; }
 unittest
 {
 
-    scope DmdInitGuard guard = DmdInitGuard.make();
+    scope const(DmdInitGuard) _ = DmdInitGuard.make();
 
     string code = q{
 int foo(int n){ int i=0; for(; i<n; ++i){} return i; }
@@ -618,7 +618,7 @@ int bar(int n){ int i=0; while(i<n) ++i; return i; }
 };
     auto funcs = collectFunctionsFromSource("loop2.d", code);
     assert(funcs.length == 2);
-    auto sim = treeSimilarity(funcs[0], funcs[1]);
+    const sim = treeSimilarity(funcs[0], funcs[1]);
     // for vs while yields about 0.5 similarity
     assert(sim > 0.45 && sim < 0.55);
 }
@@ -627,7 +627,7 @@ int bar(int n){ int i=0; while(i<n) ++i; return i; }
 unittest
 {
 
-    scope DmdInitGuard guard = DmdInitGuard.make();
+    scope const(DmdInitGuard) _ = DmdInitGuard.make();
 
     string code = q{
 int foo(int x){ if(x>0){ if(x>1) return x;} return -x; }
@@ -635,7 +635,7 @@ int bar(int x){ if(x>0) return x; return -x; }
 };
     auto funcs = collectFunctionsFromSource("nested.d", code);
     assert(funcs.length == 2);
-    auto sim = treeSimilarity(funcs[0], funcs[1]);
+    const sim = treeSimilarity(funcs[0], funcs[1]);
     // Nested conditionals drop similarity to about 0.34
     assert(sim > 0.3 && sim < 0.4);
 }
@@ -644,7 +644,7 @@ int bar(int x){ if(x>0) return x; return -x; }
 unittest
 {
 
-    scope DmdInitGuard guard = DmdInitGuard.make();
+    scope const(DmdInitGuard) _ = DmdInitGuard.make();
 
     string code = q{
 int foo(){ return 1; }
@@ -652,7 +652,7 @@ void bar(string s){ import std.stdio; writeln(s); }
 };
     auto funcs = collectFunctionsFromSource("diff.d", code);
     assert(funcs.length == 2);
-    auto sim = treeSimilarity(funcs[0], funcs[1]);
+    const sim = treeSimilarity(funcs[0], funcs[1]);
     // Expect very low similarity (~0.12)
     assert(sim > 0 && sim < 0.2);
 }
@@ -661,7 +661,7 @@ void bar(string s){ import std.stdio; writeln(s); }
 unittest
 {
 
-    scope DmdInitGuard guard = DmdInitGuard.make();
+    scope const(DmdInitGuard) _ = DmdInitGuard.make();
 
     string code = q{
 int foo(int x){
@@ -695,7 +695,7 @@ unittest
 {
     import std.math : isClose;
 
-    scope DmdInitGuard guard = DmdInitGuard.make();
+    scope const(DmdInitGuard) _ = DmdInitGuard.make();
 
     string code = q{
 int foo(int a){ int x = a * 2; return x; }
@@ -703,7 +703,7 @@ int bar(int b){ int y = b * 2; return y; }
 };
     auto funcs = collectFunctionsFromSource("rename2.d", code);
     assert(funcs.length == 2);
-    auto sim = treeSimilarity(funcs[0], funcs[1]);
+    const sim = treeSimilarity(funcs[0], funcs[1]);
     // variable and parameter names differ but structure identical -> ~1.0
     assert(isClose(sim, 1.0));
 }
@@ -713,7 +713,7 @@ unittest
 {
     import std.math : isClose;
 
-    scope DmdInitGuard guard = DmdInitGuard.make();
+    scope const(DmdInitGuard) _ = DmdInitGuard.make();
 
     string code = q{
 int foo(){ return 42; }
@@ -721,7 +721,7 @@ int bar(){ return 1337; }
 };
     auto funcs = collectFunctionsFromSource("literal2.d", code);
     assert(funcs.length == 2);
-    auto sim = treeSimilarity(funcs[0], funcs[1]);
+    const sim = treeSimilarity(funcs[0], funcs[1]);
     // literals normalized -> expect 1.0
     assert(isClose(sim, 1.0));
 }
@@ -730,7 +730,7 @@ int bar(){ return 1337; }
 unittest
 {
 
-    scope DmdInitGuard guard = DmdInitGuard.make();
+    scope const(DmdInitGuard) _ = DmdInitGuard.make();
 
     string code = q{
 int foo(int n){ int i=0; do{ ++i; } while(i<n); return i; }
@@ -738,7 +738,7 @@ int bar(int n){ int i=0; while(i<n){ ++i; } return i; }
 };
     auto funcs = collectFunctionsFromSource("loop3.d", code);
     assert(funcs.length == 2);
-    auto sim = treeSimilarity(funcs[0], funcs[1]);
+    const sim = treeSimilarity(funcs[0], funcs[1]);
     import std.math : isClose;
     // do-while vs while loops retain partial structural similarity
     assert(isClose(sim, 0.461538, 0.01));
@@ -748,14 +748,14 @@ unittest
 {
     import std.math : isClose;
 
-    scope DmdInitGuard guard = DmdInitGuard.make();
+    scope const(DmdInitGuard) _ = DmdInitGuard.make();
 
     string code = q{
 int a(){ return 0; }
 int b(){ return 1; }
 };
     auto funcs = collectFunctionsFromSource("penalty.d", code);
-    auto sim = treeSimilarity(funcs[0], funcs[1], false);
+    const sim = treeSimilarity(funcs[0], funcs[1], false);
     assert(sim >= 0 && sim <= 1);
 }
 
@@ -763,7 +763,7 @@ unittest
 {
     import std.math : isClose;
 
-    scope DmdInitGuard guard = DmdInitGuard.make();
+    scope const(DmdInitGuard) _ = DmdInitGuard.make();
 
     string code = q{
 void foo(){}
@@ -771,6 +771,6 @@ void bar(){}
 };
     auto funcs = collectFunctionsFromSource("empty.d", code);
     assert(funcs.length == 2);
-    auto sim = treeSimilarity(funcs[0], funcs[1]);
+    const sim = treeSimilarity(funcs[0], funcs[1]);
     assert(isClose(sim, 1.0));
 }

--- a/source/lib/treedistance.d
+++ b/source/lib/treedistance.d
@@ -78,15 +78,15 @@ version(unittest)
 
 unittest
 {
-    auto a = Node(NodeKind.Other, "",
+    auto nodeA = Node(NodeKind.Other, "",
         [leaf(NodeKind.Identifier, "<id>"),
          leaf(NodeKind.Literal, "<lit>")]);
-    auto b = Node(NodeKind.Other, "",
+    auto nodeB = Node(NodeKind.Other, "",
         [leaf(NodeKind.Identifier, "<id>"),
          leaf(NodeKind.Literal, "<lit>"),
          leaf(NodeKind.Keyword, "if")]);
-    assert(ted(a, a) == 0);
-    assert(ted(a, b) == 1); // one insertion
+    assert(ted(nodeA, nodeA) == 0);
+    assert(ted(nodeA, nodeB) == 1); // one insertion
 
     // Deleting a subtree should cost its size (3 nodes here).
     auto complex = Node(NodeKind.Other, "",
@@ -108,7 +108,7 @@ unittest
     assert(ted(c, d) == 1);
 
     // Symmetry property.
-    assert(ted(a, b) == ted(b, a));
+    assert(ted(nodeA, nodeB) == ted(nodeB, nodeA));
 }
 
 unittest


### PR DESCRIPTION
## Summary
- document sample functions and CLI version
- tweak unit tests to appease lint
- fix unused variable warnings
- minor const correctness improvements

## Testing
- `dub lint`
- `dub test --coverage --coverage-ctfe`
- `dub run -- --dir source/lib --exclude-unittests --threshold=0.9 --min-lines=3`


------
https://chatgpt.com/codex/tasks/task_e_686e6fbccb5c832cb52f4b6bd1491a99