### PR TITLE
Simplify README development sections

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -103,28 +103,8 @@ No similar functions found.
 
 ## 開発
 
-プルリクエストを送る前に必ずテストスイートを実行してください。各モジュールで70%以上のカバレッジが求められます。
-
-```bash
-dub test --coverage --coverage-ctfe
-```
-
-テスト後、`source-*.lst` 各ファイルが少なくとも70%のカバレッジを示すか確認するため次を実行します:
-
-```bash
-rdmd ./scripts/check_coverage.d
-```
-閾値を下回るファイルがあるとスクリプトはエラーで終了します。
-
-CLI が問題なく動作するか、最小構成で確認します:
-
-```bash
-dub run -- --dir source/lib --exclude-unittests --threshold=0.9 --min-lines=3
-```
-
-## 依存関係の管理
-
-`dub upgrade` で依存関係を更新した後、テストスイートを実行してカバレッジを取得してください。テストが通ったら上記の手順でCLIが動作するか確認し、更新されたマニフェストファイルをコミットします。詳細な手順は [AGENTS.md](AGENTS.md#dependency-maintenance-dub) を参照してください。
+開発手順や依存関係の管理方法については
+[CONTRIBUTING.md](CONTRIBUTING.md) を参照してください。
 
 ## コントリビュート
 

--- a/README.md
+++ b/README.md
@@ -118,32 +118,8 @@ No similar functions found.
 
 ## Development
 
-Run the full test suite before sending a pull request.  The project expects
-coverage information to be generated and kept above 70% for each module.
-
-```bash
-dub test --coverage --coverage-ctfe
-```
-
-After running the tests, run the coverage check script to ensure each
-`source-*.lst` file reports at least 70% coverage. Development scripts live in
-the `scripts/` directory, are written in D, and should be executed with
-`rdmd` as described in [scripts/AGENTS.md](scripts/AGENTS.md):
-
-```bash
-rdmd ./scripts/check_coverage.d
-```
-The script exits with an error if any coverage file is below the threshold.
-
-To verify the command line interface still works, invoke it with a minimal
-configuration:
-
-```bash
-dub run -- --dir source/lib --exclude-unittests --threshold=0.9 --min-lines=3
-```
-
-## Dependency Maintenance
-Refresh dependencies with `dub upgrade` and then run the full test suite with coverage. If the tests pass, verify the CLI works as shown above and commit the updated manifest files. See [AGENTS.md](AGENTS.md#dependency-maintenance-dub) for the detailed procedure.
+Developer guidelines, including dependency maintenance, are available in
+[CONTRIBUTING.md](CONTRIBUTING.md).
 
 ## Contributing
 See [CONTRIBUTING.md](CONTRIBUTING.md) for workflow and guidelines.


### PR DESCRIPTION
## Summary
- clarify developer guidance by linking to CONTRIBUTING
- remove lengthy development and dependency notes in both READMEs

## Testing
- `dub test --coverage --coverage-ctfe`
- `dub run -- --dir source/lib --exclude-unittests --threshold=0.9 --min-lines=3`


------
https://chatgpt.com/codex/tasks/task_e_687388778638832caaa56efc14b1b783